### PR TITLE
fix: disable FastMCP startup banner

### DIFF
--- a/src/mcp_coda/__init__.py
+++ b/src/mcp_coda/__init__.py
@@ -42,7 +42,7 @@ def main(
         run_kwargs["host"] = host
         run_kwargs["port"] = port
 
-    asyncio.run(mcp.run_async(**run_kwargs))
+    asyncio.run(mcp.run_async(show_banner=False, **run_kwargs))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Pass `show_banner=False` to `mcp.run_async()` to suppress the FastMCP ASCII banner on server startup

## Test plan
- [ ] Server starts without banner output on stdio