### PR TITLE
fix: validate token is ASCII before passing to httpx

### DIFF
--- a/src/mcp_coda/config.py
+++ b/src/mcp_coda/config.py
@@ -42,3 +42,12 @@ class CodaConfig:
         if not self.token:
             msg = "CODA_API_TOKEN environment variable is required"
             raise ValueError(msg)
+        try:
+            self.token.encode("ascii")
+        except UnicodeEncodeError:
+            msg = (
+                "CODA_API_TOKEN contains non-ASCII characters. "
+                "The token may have been incorrectly decoded (e.g. base64). "
+                "Coda API tokens are plain ASCII strings."
+            )
+            raise ValueError(msg) from None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -73,3 +73,10 @@ class TestCodaConfig:
     def test_validate_missing_token(self) -> None:
         with pytest.raises(ValueError, match="CODA_API_TOKEN"):
             CodaConfig().validate()
+
+    def test_validate_non_ascii_token(self) -> None:
+        with pytest.raises(ValueError, match="non-ASCII"):
+            CodaConfig(token="tok\ufffd").validate()
+
+    def test_validate_ascii_token_ok(self) -> None:
+        CodaConfig(token="abc-123-def").validate()  # should not raise


### PR DESCRIPTION
## Summary
- Non-ASCII tokens (e.g. from incorrect base64 decoding) caused an unhandled `UnicodeEncodeError` in httpx during server startup
- Added ASCII validation in `config.validate()` with a clear error message pointing to the root cause
- 2 new tests for the validation

## Test plan
- [x] `test_validate_non_ascii_token` — verifies non-ASCII token raises `ValueError`
- [x] `test_validate_ascii_token_ok` — verifies valid tokens pass