### PR TITLE
chore: sync server.json and gemini-extension.json with release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,19 @@ jobs:
             [ -f "$f" ] && sed -i 's/^- \*\*Version\*\*: .*/- **Version**: ${{ steps.next.outputs.version }}/' "$f"
           done
 
+      - name: Update server.json and gemini-extension.json version
+        env:
+          NEXT_VERSION: ${{ steps.next.outputs.version }}
+        run: |
+          if [ -f server.json ]; then
+            jq --arg v "$NEXT_VERSION" '.version = $v | (.packages[]?.version) |= $v' server.json > server.json.tmp
+            mv server.json.tmp server.json
+          fi
+          if [ -f gemini-extension.json ]; then
+            jq --arg v "$NEXT_VERSION" '.version = $v' gemini-extension.json > gemini-extension.json.tmp
+            mv gemini-extension.json.tmp gemini-extension.json
+          fi
+
       - name: Regenerate uv.lock
         run: uv lock
 
@@ -165,6 +178,8 @@ jobs:
           CHANGELOG_BLOB=$(create_blob CHANGELOG.md)
           LLMS_BLOB=$(create_blob llms.txt)
           LLMS_FULL_BLOB=$(create_blob llms-full.txt)
+          SERVER_JSON_BLOB=$(create_blob server.json)
+          GEMINI_EXT_BLOB=$(create_blob gemini-extension.json)
 
           # Create tree with all release files
           NEW_TREE=$(gh api repos/${{ github.repository }}/git/trees \
@@ -202,6 +217,18 @@ jobs:
                 "mode": "100644",
                 "type": "blob",
                 "sha": "$LLMS_FULL_BLOB"
+              },
+              {
+                "path": "server.json",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "$SERVER_JSON_BLOB"
+              },
+              {
+                "path": "gemini-extension.json",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "$GEMINI_EXT_BLOB"
               }
             ]
           }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-coda",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "MCP server for Coda API — docs, pages, tables, rows, formulas, permissions, and more",
   "mcpServers": {
     "mcp-coda": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/vish288/mcp-coda",
     "source": "github"
   },
-  "version": "0.4.8",
+  "version": "0.5.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-coda",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Catch up `server.json` and `gemini-extension.json` from 0.4.8 → 0.5.0 (silently skipped by every release since 0.4.8).
- Extend `release.yml` to update both files on every release going forward and include them in the API-tree commit.

## Test plan
- [ ] Workflow dry-run produces correct version in `server.json` (top-level and `packages[0].version`) and `gemini-extension.json`.
- [ ] Real release bumps 0.5.0 → 0.5.1 and the release commit includes both files.